### PR TITLE
feat : detailpage Post

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "react-scripts": "5.0.0",
         "recoil": "^0.7.0",
         "styled-components": "^5.3.5",
+        "swr": "^1.3.0",
         "typescript": "^4.6.3",
         "web-vitals": "^2.1.4"
       },
@@ -14725,6 +14726,14 @@
         "boolbase": "~1.0.0"
       }
     },
+    "node_modules/swr": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-1.3.0.tgz",
+      "integrity": "sha512-dkghQrOl2ORX9HYrMDtPa7LTVHJjCTeZoB1dqTbnnEDlSvN8JEKpYIYurDfvbQFUUS8Cg8PceFVZNkW0KNNYPw==",
+      "peerDependencies": {
+        "react": "^16.11.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
@@ -26681,6 +26690,11 @@
           }
         }
       }
+    },
+    "swr": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-1.3.0.tgz",
+      "integrity": "sha512-dkghQrOl2ORX9HYrMDtPa7LTVHJjCTeZoB1dqTbnnEDlSvN8JEKpYIYurDfvbQFUUS8Cg8PceFVZNkW0KNNYPw=="
     },
     "symbol-tree": {
       "version": "3.2.4",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "react-scripts": "5.0.0",
     "recoil": "^0.7.0",
     "styled-components": "^5.3.5",
+    "swr": "^1.3.0",
     "typescript": "^4.6.3",
     "web-vitals": "^2.1.4"
   },

--- a/src/api/mainPageApi.ts
+++ b/src/api/mainPageApi.ts
@@ -1,0 +1,6 @@
+import axios from "axios";
+
+export const MainPagefetcher = async () => {
+  const res = await axios.get("http://localhost:5000/");
+  return res.data;
+};

--- a/src/components/detailPost/DetailPost.tsx
+++ b/src/components/detailPost/DetailPost.tsx
@@ -1,0 +1,209 @@
+import React, { useState } from "react";
+import styled, { css } from "styled-components";
+import {
+  Title,
+  Author,
+  Content,
+  ArrowContainer,
+  PropsType,
+} from "../mainpost/MainPost";
+import { IoClose } from "react-icons/io5";
+import { MdKeyboardArrowLeft, MdKeyboardArrowRight } from "react-icons/md";
+import { HiOutlineHeart } from "react-icons/hi";
+
+const Wrapper = styled.div`
+  box-sizing: border-box;
+  width: 711px;
+  height: auto;
+  background-color: #f8f8f8;
+  box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
+  border-radius: 20px;
+  margin: 20px auto;
+  padding-top: 50px;
+  padding-bottom: 50px;
+  //border: 2px solid yellow;
+`;
+
+const Inner = styled.div`
+  position: relative;
+  width: 613px;
+  height: 900px;
+  margin: 0 auto;
+`;
+
+const DetailTItle = styled(Title)`
+  line-height: 35px;
+  font-size: 24px;
+  width: 400px;
+  height: 35px;
+`;
+
+const DetailAuthor = styled(Author)`
+  line-height: 23px;
+  font-size: 16px;
+  width: 50px;
+  height: 23px;
+  font-weight: 700;
+  right: 200px;
+  bottom: 0;
+`;
+
+const DetailContent = styled(Content)`
+  width: auto;
+  font-weight: 700;
+  margin-top: 40px;
+`;
+
+const Close = styled(IoClose)`
+  position: absolute;
+  top: 0;
+  right: 0;
+  font-size: 30px;
+  cursor: pointer;
+`;
+
+const ImgWrapper = styled.div`
+  display: flex;
+  height: 362px;
+  border-radius: 10px;
+  overflow: hidden;
+`;
+
+const ImageBox = styled.div<{ sliderCount: number }>`
+  width: 613px;
+  height: 362px;
+  background-color: #e5e5e5;
+  flex-shrink: 0;
+  ${({ sliderCount }) =>
+    sliderCount === 1 &&
+    css`
+      transform: translateX(-613px);
+    `}
+  ${({ sliderCount }) =>
+    sliderCount === 2 &&
+    css`
+      transform: translateX(-1226px);
+    `}
+  ${({ sliderCount }) =>
+    sliderCount === 3 &&
+    css`
+      transform: translateX(-1839px);
+    `}
+  ${({ sliderCount }) =>
+    sliderCount === 4 &&
+    css`
+      transform: translateX(-2452px);
+    `}
+  ${({ sliderCount }) =>
+    sliderCount === 5 &&
+    css`
+      transform: translateX(-3065px);
+    `}
+  transition: .5s;
+`;
+
+const MyImg = styled.img`
+  width: 613px;
+  height: 362px;
+  object-fit: contain;
+`;
+
+const DetailArrowContainer = styled(ArrowContainer)`
+  bottom: 530px;
+`;
+
+const BelowInner = styled.div`
+  position: relative;
+  box-sizing: border-box;
+  width: 613px;
+  height: 32px;
+  color: #00964a;
+  font-size: 18px;
+  margin-top: 32px;
+  font-weight: 700;
+`;
+
+const MyHiOutlineHeart = styled(HiOutlineHeart)`
+  position: absolute;
+  font-size: 22px;
+  top: 1px;
+  right: 16px;
+`;
+
+const MyComment = styled.span`
+  position: absolute;
+  left: 0;
+`;
+
+const CommentNum = styled.span`
+  position: absolute;
+  left: 40px;
+`;
+const LikeNum = styled.span`
+  position: absolute;
+  right: 0;
+`;
+
+const Line = styled.div`
+  width: 613px;
+  height: 1px;
+  background-color: #00964a;
+  position: absolute;
+  top: 42px;
+`;
+
+export default function DetailPost({
+  postId,
+  author,
+  title,
+  content,
+  imgUrl,
+  like,
+  comment,
+}: PropsType): JSX.Element {
+  const [sliderCount, setSliderCount] = useState<number>(0);
+
+  const handleSliderToLeft = (): void => {
+    setSliderCount((prev) => prev - 1);
+  };
+
+  const handleSliderToRight = (): void => {
+    setSliderCount((prev) => prev + 1);
+  };
+
+  return (
+    <Wrapper>
+      <Inner>
+        <DetailTItle>{title}</DetailTItle>
+        <DetailAuthor>{author}</DetailAuthor>
+        <DetailContent>{content}</DetailContent>
+        <Close />
+        <ImgWrapper>
+          {imgUrl.map((url, index) => (
+            <ImageBox sliderCount={sliderCount} key={index}>
+              <MyImg src={url} alt={`image${index + 1}`} />
+            </ImageBox>
+          ))}
+        </ImgWrapper>
+        {sliderCount > 0 && (
+          <DetailArrowContainer pos={"left"} onClick={handleSliderToLeft}>
+            <MdKeyboardArrowLeft />
+          </DetailArrowContainer>
+        )}
+        {sliderCount < 4 && (
+          <DetailArrowContainer pos={"right"} onClick={handleSliderToRight}>
+            <MdKeyboardArrowRight />
+          </DetailArrowContainer>
+        )}
+        <BelowInner>
+          <MyHiOutlineHeart />
+          <LikeNum>{like}</LikeNum>
+          <MyComment>댓글</MyComment>
+          <CommentNum>{comment.length}</CommentNum>
+          <Line />
+          {/* <CommentInput> */}
+        </BelowInner>
+      </Inner>
+    </Wrapper>
+  );
+}

--- a/src/components/mainpost/CommentInput.tsx
+++ b/src/components/mainpost/CommentInput.tsx
@@ -28,11 +28,11 @@ const MyImPlay3 = styled(ImPlay3)`
 export default function CommentInput(): JSX.Element {
   const [comment, setComment] = useState<string>("");
 
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>): void => {
     setComment(e.target.value);
   };
 
-  const handleClick = () => {
+  const handleClick = (): void => {
     // axios.post("uri", {
     //   userId: "",
     //   postId: "",
@@ -41,7 +41,7 @@ export default function CommentInput(): JSX.Element {
     alert(comment);
   };
 
-  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>): void => {
     if (e.key === "Enter") {
       // axios.post("uri", {
       //   userId: "",

--- a/src/components/mainpost/ImageContainer.tsx
+++ b/src/components/mainpost/ImageContainer.tsx
@@ -6,19 +6,19 @@ interface propsType {
   silderCount: number;
 }
 
-const ImageBox = styled.div<{ silderCount: number }>`
+const ImageBox = styled.div<{ sliderCount: number }>`
   width: 142px;
   height: 134px;
   background-color: #e5e5e5;
   margin: 0 14px 0 0;
   flex-shrink: 0;
-  ${({ silderCount }) =>
-    silderCount === 1 &&
+  ${({ sliderCount }) =>
+    sliderCount === 1 &&
     css`
       transform: translateX(-156px);
     `}
-  ${({ silderCount }) =>
-    silderCount === 2 &&
+  ${({ sliderCount }) =>
+    sliderCount === 2 &&
     css`
       transform: translateX(-312px);
     `}
@@ -36,7 +36,7 @@ export default function ImageContainer({
   silderCount,
 }: propsType): JSX.Element {
   return (
-    <ImageBox silderCount={silderCount}>
+    <ImageBox sliderCount={silderCount}>
       <MyImg src={url} alt={"필요할까?"} />
     </ImageBox>
   );

--- a/src/components/mainpost/MainPost.tsx
+++ b/src/components/mainpost/MainPost.tsx
@@ -10,7 +10,8 @@ import { HiOutlineHeart } from "react-icons/hi";
 import ImageContainer from "./ImageContainer";
 import CommentInput from "./CommentInput";
 
-interface PropsType {
+export interface PropsType {
+  postId: string;
   author: string;
   title: string;
   content: string;
@@ -37,7 +38,7 @@ const Inner = styled.div`
   margin: 0 auto;
 `;
 
-const Title = styled.h1`
+export const Title = styled.h1`
   display: inline-block;
   box-sizing: border-box;
   color: #00964a;
@@ -46,11 +47,10 @@ const Title = styled.h1`
   font-size: 18px;
   width: 300px;
   height: 26px;
-  margin-top: 0;
   margin: 0 auto;
 `;
 
-const Author = styled.p`
+export const Author = styled.p`
   position: absolute;
   display: inline-block;
   box-sizing: border-box;
@@ -64,7 +64,7 @@ const Author = styled.p`
   margin: 0 auto;
 `;
 
-const Content = styled.p`
+export const Content = styled.p`
   box-sizing: border-box;
   font-weight: 400;
   line-height: 18.82px;
@@ -80,7 +80,7 @@ const SlideWrapper = styled.div`
   overflow: hidden;
 `;
 
-const ArrowContainer = styled.div<{ pos: "left" | "right" }>`
+export const ArrowContainer = styled.div<{ pos: "left" | "right" }>`
   display: flex;
   justify-content: center;
   align-items: center;
@@ -112,7 +112,6 @@ const BelowInner = styled.div`
   box-sizing: border-box;
   width: 488px;
   padding: 0;
-  background-color: skyblue;
   color: #00964a;
   font-size: 12px;
   margin: 8px auto;
@@ -147,6 +146,7 @@ const Line = styled.div`
 `;
 
 export default function MainPost({
+  postId,
   author,
   title,
   content,
@@ -156,11 +156,11 @@ export default function MainPost({
 }: PropsType): JSX.Element {
   const [sliderCount, setSliderCount] = useState<number>(0);
 
-  const handleSliderToLeft = () => {
+  const handleSliderToLeft = (): void => {
     setSliderCount((prev) => prev - 1);
   };
 
-  const handleSliderToRight = () => {
+  const handleSliderToRight = (): void => {
     setSliderCount((prev) => prev + 1);
   };
 


### PR DESCRIPTION
detail page의 post component -
구분선 위 까지 완료 (title, author, content, image silder, comment&like indicator)


![화면 캡처 2022-05-05 172032](https://user-images.githubusercontent.com/86838865/166895603-5885dd9b-9f08-45ff-bfc6-f30d440cc2e5.png)
