### PR TITLE
feat(DetailPost.tsx): comment input and comment list

### DIFF
--- a/src/api/mainPageApi.ts
+++ b/src/api/mainPageApi.ts
@@ -1,6 +1,6 @@
 import axios from "axios";
 
-export const MainPagefetcher = async () => {
+export const mainPagefetcher = async () => {
   const res = await axios.get("http://localhost:5000/");
   return res.data;
 };

--- a/src/components/detailPost/Comment.tsx
+++ b/src/components/detailPost/Comment.tsx
@@ -1,0 +1,34 @@
+import React from "react";
+import styled from "styled-components";
+
+interface propType {
+  author: string;
+  content: string;
+}
+
+const Wrapper = styled.div`
+  position: relative;
+  display: flex;
+  font-weight: 700;
+  margin-top: 20px;
+`;
+
+const Author = styled.span`
+  font-size: 18px;
+  margin-right: 30px;
+`;
+
+const Content = styled.p`
+  font-size: 14px;
+  margin: 0;
+  line-height: 2;
+`;
+
+export default function Comment({ author, content }: propType): JSX.Element {
+  return (
+    <Wrapper>
+      <Author>{author}</Author>
+      <Content>{content}</Content>
+    </Wrapper>
+  );
+}

--- a/src/components/detailPost/DetailCommentInput.tsx
+++ b/src/components/detailPost/DetailCommentInput.tsx
@@ -1,0 +1,75 @@
+import React, { useState } from "react";
+import styled from "styled-components";
+
+const CommentAuthor = styled.span`
+  font-size: 18px;
+  font-weight: 700;
+  margin-right: 30px;
+`;
+
+const MyInput = styled.input`
+  box-sizing: border-box;
+  background-color: #f8f8f8;
+  width: 469px;
+  height: 36px;
+  border-radius: 12px;
+  box-shadow: inset 0px 4px 4px rgba(0, 0, 0, 0.25);
+  position: relative;
+  border: 1px solid #7e7e7e;
+  text-indent: 18px;
+  font-size: 14px;
+`;
+
+const SubmitBtn = styled.button`
+  width: 47px;
+  height: 26px;
+  margin-left: 8px;
+  background-color: #00964a;
+  color: #fff;
+  font-size: 13px;
+  border-radius: 4px;
+  box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
+  cursor: pointer;
+`;
+
+export default function DetailCommentInput(): JSX.Element {
+  const [comment, setComment] = useState<string>("");
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>): void => {
+    setComment(e.target.value);
+  };
+
+  const handleClick = (): void => {
+    // axios.post("uri", {
+    //   userId: "",
+    //   postId: "",
+    //   comment: comment,
+    // });
+    alert(comment);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>): void => {
+    if (e.key === "Enter") {
+      // axios.post("uri", {
+      //   userId: "",
+      //   postId: "",
+      //   comment: comment,
+      // });
+      alert(comment);
+    }
+  };
+  return (
+    <>
+      <CommentAuthor>{"이혜영"}</CommentAuthor>
+      <MyInput
+        type="text"
+        placeholder="댓글을 입력하세요"
+        value={comment}
+        onChange={handleChange}
+        maxLength={30}
+        onKeyDown={handleKeyDown}
+      />
+      <SubmitBtn onClick={handleClick}>등록</SubmitBtn>
+    </>
+  );
+}

--- a/src/components/detailPost/DetailPost.tsx
+++ b/src/components/detailPost/DetailPost.tsx
@@ -1,5 +1,5 @@
-import React, { useState } from "react";
-import styled, { css } from "styled-components";
+import React, { useEffect, useState } from "react";
+import styled from "styled-components";
 import {
   Title,
   Author,
@@ -10,6 +10,8 @@ import {
 import { IoClose } from "react-icons/io5";
 import { MdKeyboardArrowLeft, MdKeyboardArrowRight } from "react-icons/md";
 import { HiOutlineHeart } from "react-icons/hi";
+import DetailCommentInput from "./DetailCommentInput";
+import Comment from "./Comment";
 
 const Wrapper = styled.div`
   box-sizing: border-box;
@@ -20,14 +22,14 @@ const Wrapper = styled.div`
   border-radius: 20px;
   margin: 20px auto;
   padding-top: 50px;
-  padding-bottom: 50px;
+  padding-bottom: 20px;
   //border: 2px solid yellow;
 `;
 
 const Inner = styled.div`
   position: relative;
   width: 613px;
-  height: 900px;
+  height: auto;
   margin: 0 auto;
 `;
 
@@ -69,37 +71,13 @@ const ImgWrapper = styled.div`
   overflow: hidden;
 `;
 
-const ImageBox = styled.div<{ sliderCount: number }>`
+const ImageBox = styled.div<{ transformWidth: string }>`
   width: 613px;
   height: 362px;
   background-color: #e5e5e5;
   flex-shrink: 0;
-  ${({ sliderCount }) =>
-    sliderCount === 1 &&
-    css`
-      transform: translateX(-613px);
-    `}
-  ${({ sliderCount }) =>
-    sliderCount === 2 &&
-    css`
-      transform: translateX(-1226px);
-    `}
-  ${({ sliderCount }) =>
-    sliderCount === 3 &&
-    css`
-      transform: translateX(-1839px);
-    `}
-  ${({ sliderCount }) =>
-    sliderCount === 4 &&
-    css`
-      transform: translateX(-2452px);
-    `}
-  ${({ sliderCount }) =>
-    sliderCount === 5 &&
-    css`
-      transform: translateX(-3065px);
-    `}
-  transition: .5s;
+  transform: translateX(${(props) => props.transformWidth});
+  transition: 0.5s;
 `;
 
 const MyImg = styled.img`
@@ -109,7 +87,8 @@ const MyImg = styled.img`
 `;
 
 const DetailArrowContainer = styled(ArrowContainer)`
-  bottom: 530px;
+  bottom: 220px;
+  color: #000;
 `;
 
 const BelowInner = styled.div`
@@ -152,6 +131,18 @@ const Line = styled.div`
   top: 42px;
 `;
 
+const CommentBox = styled.div`
+  margin-top: 28px;
+`;
+
+const OpenIt = styled.div`
+  width: 90px;
+  font-size: 12px;
+  margin: 13px auto 0;
+  padding: 8px;
+  cursor: pointer;
+`;
+
 export default function DetailPost({
   postId,
   author,
@@ -162,6 +153,16 @@ export default function DetailPost({
   comment,
 }: PropsType): JSX.Element {
   const [sliderCount, setSliderCount] = useState<number>(0);
+  const [commentOpened, setCommentOpened] = useState<boolean>(false);
+
+  const [OpenedComment, setOpenedComment] =
+    useState<Array<{ author: string; content: string }>>(comment);
+
+  useEffect(() => {
+    setOpenedComment((prev) => {
+      return [prev[0], prev[1]];
+    });
+  }, [OpenedComment]);
 
   const handleSliderToLeft = (): void => {
     setSliderCount((prev) => prev - 1);
@@ -169,6 +170,10 @@ export default function DetailPost({
 
   const handleSliderToRight = (): void => {
     setSliderCount((prev) => prev + 1);
+  };
+
+  const handleOpenIt = (): void => {
+    setCommentOpened((prev) => !prev);
   };
 
   return (
@@ -180,29 +185,51 @@ export default function DetailPost({
         <Close />
         <ImgWrapper>
           {imgUrl.map((url, index) => (
-            <ImageBox sliderCount={sliderCount} key={index}>
+            <ImageBox key={index} transformWidth={`${sliderCount * -613}px`}>
               <MyImg src={url} alt={`image${index + 1}`} />
             </ImageBox>
           ))}
         </ImgWrapper>
-        {sliderCount > 0 && (
-          <DetailArrowContainer pos={"left"} onClick={handleSliderToLeft}>
-            <MdKeyboardArrowLeft />
-          </DetailArrowContainer>
-        )}
-        {sliderCount < 4 && (
-          <DetailArrowContainer pos={"right"} onClick={handleSliderToRight}>
-            <MdKeyboardArrowRight />
-          </DetailArrowContainer>
-        )}
         <BelowInner>
+          {sliderCount > 0 && (
+            <DetailArrowContainer pos={"left"} onClick={handleSliderToLeft}>
+              <MdKeyboardArrowLeft />
+            </DetailArrowContainer>
+          )}
+          {sliderCount < 4 && (
+            <DetailArrowContainer pos={"right"} onClick={handleSliderToRight}>
+              <MdKeyboardArrowRight />
+            </DetailArrowContainer>
+          )}
           <MyHiOutlineHeart />
           <LikeNum>{like}</LikeNum>
           <MyComment>댓글</MyComment>
           <CommentNum>{comment.length}</CommentNum>
           <Line />
-          {/* <CommentInput> */}
         </BelowInner>
+        <CommentBox>
+          <DetailCommentInput />
+          {commentOpened
+            ? comment.map((_comment, index) => (
+                <Comment
+                  author={_comment.author}
+                  content={_comment.content}
+                  key={index}
+                />
+              ))
+            : OpenedComment.map((_comment, index) => (
+                <Comment
+                  author={_comment.author}
+                  content={_comment.content}
+                  key={index}
+                />
+              ))}
+          {commentOpened ? (
+            <OpenIt onClick={handleOpenIt}>{". . . 간략히 보기"}</OpenIt>
+          ) : (
+            <OpenIt onClick={handleOpenIt}>{". . . 펼쳐보기"}</OpenIt>
+          )}
+        </CommentBox>
       </Inner>
     </Wrapper>
   );

--- a/src/components/mainpost/ImageContainer.tsx
+++ b/src/components/mainpost/ImageContainer.tsx
@@ -3,25 +3,16 @@ import styled, { css } from "styled-components";
 
 interface propsType {
   url: string;
-  silderCount: number;
+  sliderCount: number;
 }
 
-const ImageBox = styled.div<{ sliderCount: number }>`
+const ImageBox = styled.div<{ transformWidth: string }>`
   width: 142px;
   height: 134px;
   background-color: #e5e5e5;
   margin: 0 14px 0 0;
   flex-shrink: 0;
-  ${({ sliderCount }) =>
-    sliderCount === 1 &&
-    css`
-      transform: translateX(-156px);
-    `}
-  ${({ sliderCount }) =>
-    sliderCount === 2 &&
-    css`
-      transform: translateX(-312px);
-    `}
+  transform: translateX(${(props) => props.transformWidth});
   transition: 1s;
 `;
 
@@ -33,10 +24,10 @@ const MyImg = styled.img`
 
 export default function ImageContainer({
   url,
-  silderCount,
+  sliderCount,
 }: propsType): JSX.Element {
   return (
-    <ImageBox sliderCount={silderCount}>
+    <ImageBox transformWidth={`${sliderCount * -156}px`}>
       <MyImg src={url} alt={"필요할까?"} />
     </ImageBox>
   );

--- a/src/components/mainpost/MainPost.tsx
+++ b/src/components/mainpost/MainPost.tsx
@@ -17,7 +17,7 @@ export interface PropsType {
   content: string;
   imgUrl: string[];
   like: number;
-  comment: string[];
+  comment: { author: string; content: string }[];
 }
 
 const Wrapper = styled.div`
@@ -172,7 +172,7 @@ export default function MainPost({
         <Content>{content}</Content>
         <SlideWrapper>
           {imgUrl.map((url, index) => (
-            <ImageContainer url={url} key={index} silderCount={sliderCount} />
+            <ImageContainer url={url} key={index} sliderCount={sliderCount} />
           ))}
         </SlideWrapper>
         {sliderCount > 0 && (


### PR DESCRIPTION
댓글 입력란과 댓글 리스트 개발했습니다.
최초 렌더링시 2개의 댓글만 보이며 '...펼쳐보기' 클릭 시에 모든 댓글이 보이도록 했습니다.
다시 '...간략히보기'를 누르면 2개의 댓글만 보이게 됩니다.

![detailpost](https://user-images.githubusercontent.com/86838865/167243597-f1534542-3f96-422f-8fd0-df335c3cd783.png)

![detailpost-openit](https://user-images.githubusercontent.com/86838865/167243601-32fd0801-de6d-4600-8645-dc3b0955f257.png)

