### PR TITLE
feat : 상세 포스트 전환 기능 추가

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import MainPage from "./pages/MainPage";
 import LeftSide from "./components/left/LeftSide";
 import RightSide from "./components/mainPost/RightSide";
 import LoginPage from "./pages/LoginPage";
+import DetailPage from "./pages/DetailPage";
 import NotFound from "./pages/NotFound";
 import PostPage from "./pages/PostPage";
 import styled from "styled-components";
@@ -30,6 +31,7 @@ function App() {
           <Route path="/" element={<MainPage />} />
           <Route path="post" element={<PostPage />} />
           <Route path="login" element={<LoginPage />} />
+          <Route path="detailPost/:postId" element={<DetailPage />} />
           <Route path="*" element={<NotFound />} />
         </Routes>
         <RightSide />

--- a/src/api/getPostApi.ts
+++ b/src/api/getPostApi.ts
@@ -1,1 +1,6 @@
-export {};
+import axios from "axios";
+
+export const postfetcher = async (postId: string) => {
+  const res = await axios.get(`http://localhost:5000/post/:${postId}`);
+  return res.data;
+};

--- a/src/components/detailPost/DetailPost.tsx
+++ b/src/components/detailPost/DetailPost.tsx
@@ -1,18 +1,13 @@
 import React, { useEffect, useState } from "react";
 import styled from "styled-components";
-import {
-  Title,
-  Author,
-  Content,
-  ArrowContainer,
-  PropsType,
-} from "../mainPost/MainPost";
+import { Title, Author, Content, ArrowContainer } from "../mainPost/MainPost";
 import { IoClose } from "react-icons/io5";
 import { MdKeyboardArrowLeft, MdKeyboardArrowRight } from "react-icons/md";
 import { HiOutlineHeart } from "react-icons/hi";
 import DetailCommentInput from "./DetailCommentInput";
 import Comment from "./Comment";
-
+import { PostType } from "../../type/dataType";
+import { useNavigate } from "react-router-dom";
 const Wrapper = styled.div`
   box-sizing: border-box;
   width: 711px;
@@ -151,7 +146,8 @@ export default function DetailPost({
   imgUrl,
   like,
   comment,
-}: PropsType): JSX.Element {
+}: PostType): JSX.Element {
+  const navigate = useNavigate();
   const [sliderCount, setSliderCount] = useState<number>(0);
   const [commentOpened, setCommentOpened] = useState<boolean>(false);
 
@@ -176,13 +172,17 @@ export default function DetailPost({
     setCommentOpened((prev) => !prev);
   };
 
+  const handleClose = (): void => {
+    navigate(-1);
+  };
+
   return (
     <Wrapper>
       <Inner>
         <DetailTItle>{title}</DetailTItle>
         <DetailAuthor>{author}</DetailAuthor>
         <DetailContent>{content}</DetailContent>
-        <Close />
+        <Close onClick={handleClose} />
         <ImgWrapper>
           {imgUrl.map((url, index) => (
             <ImageBox key={index} transformWidth={`${sliderCount * -613}px`}>

--- a/src/components/left/LeftSide.tsx
+++ b/src/components/left/LeftSide.tsx
@@ -1,78 +1,79 @@
 import styled from "styled-components";
 import logo from "../../img/logo.svg";
-import { ReactComponent as MoveToMain } from '../../img/chat.svg';
-import { ReactComponent as MoveToAdd } from '../../img/addPost.svg';
-import { ReactComponent as MoveToMajor } from '../../img/chemistry.svg';
-import { Link } from 'react-router-dom';
+import { ReactComponent as MoveToMain } from "../../img/chat.svg";
+import { ReactComponent as MoveToAdd } from "../../img/addPost.svg";
+import { ReactComponent as MoveToMajor } from "../../img/chemistry.svg";
+import { Link } from "react-router-dom";
 
 const Left = styled.div`
   /* position: absolute; */
   width: 113px;
+  min-width: 113px;
   height: 100%;
   display: flex;
   flex-direction: column;
   justify-content: space-between;
   align-items: center;
   padding: 25px 0 64.35185185185vh 0;
-  background-color: #F8F8F8;
+  background-color: #f8f8f8;
   box-shadow: 4px 0px 4px 0px rgba(0, 0, 0, 0.15);
   box-sizing: border-box;
-`
+`;
 
 const Logo = styled.img`
   width: 53.501800537109375px;
   height: 32px;
   margin-bottom: 14px;
   cursor: pointer;
-`
+`;
 
 const StyledMoveToMain = styled(MoveToMain)`
   width: 32px;
-  fill: #7E7E7E;
+  fill: #7e7e7e;
   cursor: pointer;
 
   :hover {
-    fill: #00964A
+    fill: #00964a;
   }
-`
+`;
 
 const StyledMoveToMajor = styled(MoveToMajor)`
   width: 32px;
-  fill: #7E7E7E;
+  fill: #7e7e7e;
   cursor: pointer;
 
   :hover {
-    fill: #00964A
+    fill: #00964a;
   }
-`
+`;
 
 const StyledMoveToAdd = styled(MoveToAdd)`
   width: 32px;
-  fill: #7E7E7E;
+  fill: #7e7e7e;
   cursor: pointer;
 
   :hover {
-    fill: #00964A
+    fill: #00964a;
   }
-`
+`;
 
-function LeftSide():JSX.Element {
-    return (
-        <Left>
-          <Link to = "/">
-            <Logo src={logo}></Logo>
-          </Link>
-          <Link to = "/">
-            <StyledMoveToMain />
-          </Link>
-          <Link to = "/post">
-            <StyledMoveToAdd />
-          </Link>
-          <Link to = "#">
-            <StyledMoveToMajor />
-          </Link>
-        </Left>
-    )
+function LeftSide(): JSX.Element {
+  return (
+    <Left>
+      <Link to="/">
+        <Logo src={logo}></Logo>
+      </Link>
+      <Link to="/">
+        <StyledMoveToMain />
+      </Link>
+      <Link to="/post">
+        <StyledMoveToAdd />
+      </Link>
+      <Link to="#">
+        <StyledMoveToMajor />
+      </Link>
+    </Left>
+  );
 }
 
 export default LeftSide;

--- a/src/components/mainpost/MainPost.tsx
+++ b/src/components/mainpost/MainPost.tsx
@@ -10,17 +10,10 @@ import { HiOutlineHeart } from "react-icons/hi";
 import ImageContainer from "./ImageContainer";
 import CommentInput from "./CommentInput";
 import PostPage from "../../pages/PostPage";
-
-export interface PropsType {
-  postId: string;
-  author: string;
-  title: string;
-  content: string;
-  imgUrl: string[];
-  like: number;
-  comment: { author: string; content: string }[];
-}
-
+import { useNavigate } from "react-router-dom";
+import { PostType } from "../../type/dataType";
+import { useRecoilState } from "recoil";
+import { scrolledState } from "../../recoil/store";
 const Wrap = styled.div`
   position: relative;
   display: flex;
@@ -57,6 +50,7 @@ export const Title = styled.h1`
   width: 300px;
   height: 26px;
   margin: 0 auto;
+  cursor: pointer;
 `;
 
 export const Author = styled.p`
@@ -162,9 +156,10 @@ export default function MainPost({
   imgUrl,
   like,
   comment,
-}: PropsType): JSX.Element {
+}: PostType): JSX.Element {
+  const [srolled, setScrolled] = useRecoilState<number>(scrolledState);
   const [sliderCount, setSliderCount] = useState<number>(0);
-
+  const navigate = useNavigate();
   const handleSliderToLeft = (): void => {
     setSliderCount((prev) => prev - 1);
   };
@@ -172,12 +167,16 @@ export default function MainPost({
   const handleSliderToRight = (): void => {
     setSliderCount((prev) => prev + 1);
   };
+  const SwitchDetail = (): void => {
+    navigate(`./detailPost/${postId}`);
+    sessionStorage.setItem("scrolledHeight", `${srolled}`);
+  };
 
   return (
     <Wrap>
       <Wrapper>
         <Inner>
-          <Title>{title}</Title>
+          <Title onClick={SwitchDetail}>{title}</Title>
           <Author>{author}</Author>
           <Content>{content}</Content>
           <SlideWrapper>

--- a/src/pages/DetailPage.tsx
+++ b/src/pages/DetailPage.tsx
@@ -2,15 +2,10 @@ import axios from "axios";
 import { useState, useEffect } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import styled from "styled-components";
-import LeftSide from "../components/left/LeftSide";
-import RightSide from "../components/mainPost/RightSide";
-import DetailCommentInput from "../components/detailPost/DetailCommentInput";
-
-import { HiOutlineHeart } from "react-icons/hi"; // 빈 하트
-import { HiHeart } from "react-icons/hi"; // 채워진 하트
-import { HiOutlineX } from "react-icons/hi"; // 닫힘 버튼
-
+import DetailPost from "../components/detailPost/DetailPost";
+import { postfetcher } from "../api/getPostApi";
 // 댓글 몇개 보여줄지 정하고 펼쳐보기 기능 추가해야함
+import { PostType } from "../type/dataType";
 
 const Wrap = styled.div`
   display: flex;
@@ -21,224 +16,41 @@ const Wrap = styled.div`
   background-color: #00000073;
 `;
 
-const Cont = styled.div`
-  display: flex;
-  flex-direction: column;
-  width: 711px;
-  height: auto;
-  border-radius: 20px;
-  background-color: #f8f8f8;
-  box-shadow: 0px 4px 4px 0px #00000040;
-  box-sizing: border-box;
-  padding: 50px 56px 0 55px;
+const PostBox = styled.div`
+  height: 100%;
+  overflow: auto;
 `;
-
-const TitleWrap = styled.div`
-  position: relative;
-  display: flex;
-  align-items: baseline;
-`;
-
-const Text = styled.p<{ fontSize: string; fontWeight: number }>`
-  font-size: ${({ fontSize }) => fontSize};
-  font-weight: ${({ fontWeight }) => fontWeight};
-  color: ${({ color }) => color};
-`;
-const Title = styled(Text)`
-  margin-right: 14px;
-`;
-const UserName = styled(Text)``;
-
-const StyledHiOutlineX = styled(HiOutlineX)`
-  position: absolute;
-  display: flex;
-  align-self: flex-end;
-  font-size: 18px;
-  color: #290606;
-  right: 0;
-  overflow: hidden;
-`;
-
-const Content = styled(Text)`
-  width: 80%;
-  margin: 41px 0 50px 0;
-`;
-
-const ImgCont = styled.div`
-  width: 600px;
-  height: 362px;
-  border-radius: 10px;
-  background-color: #e5e5e5;
-  overflow: hidden;
-`;
-
-// 두 개 이하일때 크기 변경해야함
-const Img = styled.img`
-  width: 50%;
-  height: 50%;
-  /* object-fit: cover; */ // 비율을 유지할까 말까....
-`;
-
-const NumInfo = styled.div`
-  display: flex;
-  justify-content: space-between;
-  padding: 44px 0 15px 0;
-  border-bottom: 0.75px solid #00964a;
-  margin-bottom: 21px;
-`;
-
-const LikeWrap = styled.div`
-  display: flex;
-  align-items: center;
-`;
-
-const LikeNum = styled(Text)`
-  margin-left: 8px;
-`;
-
-const CommentNum = styled(Text)`
-  ::before {
-    content: "댓글";
-    margin: 9px;
-  }
-`;
-
-const CommentWrap = styled.div`
-  display: flex;
-  align-items: center;
-  margin-bottom: 20px;
-`;
-
-const Author = styled(Text)`
-  margin-right: 30px;
-`;
-const Comment = styled(Text)``;
-
-const Test = styled(Text)``;
-
-interface DetailData {
-  postId: number;
-  title: string;
-  author: string;
-  content: string;
-  imgUrl: string[];
-  like: number;
-  comment: string[];
-}
-
-// interface Data {
-//     author: string;
-//     content: string;
-// }
 
 function DetailPage() {
-  // document.title = '제품 상세'
-  // let id =  useParams();
-  let id = 1;
-
-  const [detail, setDetail] = useState<DetailData>();
-  const [comment, setComment] = useState<string[]>();
-  const [isLike, setIsLike] = useState(false);
-  const [likeNum, setLikeNum] = useState(0);
-  const navigate = useNavigate();
+  const [data, setdata] = useState<PostType | null>();
+  const { postId } = useParams();
 
   useEffect(() => {
-    axios
-      .get(`http://localhost:3001/posts?postid=${id}`)
-      .then(function (response) {
-        const res = response.data;
-
-        for (const i of res) {
-          if (i.postId == id) setDetail(i);
-        }
-      })
-      .catch(function (error) {
-        // 에러 핸들링
-        console.log(error);
-      })
-      .then(function () {
-        // 항상 실행되는 영역
+    postId &&
+      postfetcher(postId).then((res) => {
+        setdata(res);
+        console.log(data);
       });
   }, []);
 
-  useEffect(() => {
-    setComment(detail?.comment);
-  }, []);
-
-  const clickLike = (): void => {
-    if (isLike == false) {
-      setIsLike(true);
-      setLikeNum(0);
-    } else {
-      setIsLike(false);
-      setLikeNum(1);
-    }
-  };
-
   return (
-    <>
-      <LeftSide />
-      <Wrap>
-        <Cont>
-          <TitleWrap>
-            <Title fontSize={"24px"} fontWeight={700} color={"#00964A"}>
-              {detail && detail.title}
-            </Title>
-            <UserName fontSize={"16px"} fontWeight={400} color={"#7E7E7E"}>
-              {detail && detail.author}
-            </UserName>
-            <StyledHiOutlineX onClick={() => navigate(-1)} />
-          </TitleWrap>
-          <Content fontSize={"18px"} fontWeight={700} color={"#000"}>
-            {detail && detail.content}
-          </Content>
-          <ImgCont>
-            {detail?.imgUrl.map((data) => {
-              return <Img src={data}></Img>;
-            })}
-          </ImgCont>
-
-          <NumInfo>
-            <LikeWrap>
-              {isLike ? (
-                <HiOutlineHeart onClick={clickLike} color="#00964A" />
-              ) : (
-                <HiHeart onClick={clickLike} color="#00964A" />
-              )}
-              <LikeNum fontSize={"18px"} fontWeight={700} color={"#00964A"}>
-                {detail && detail.like + likeNum}
-              </LikeNum>
-            </LikeWrap>
-
-            <CommentNum fontSize={"18px"} fontWeight={700} color={"#00964A"}>
-              {detail && detail.comment.length}
-            </CommentNum>
-          </NumInfo>
-
-          <DetailCommentInput />
-
-          {/* 수정 필요: map 안됨, 펼쳐보기 */}
-          {detail?.comment.map((data) => {
-            return (
-              <CommentWrap>
-                <Author fontSize={"18px"} fontWeight={700} color={"#000"}>
-                  이름
-                </Author>
-                <Comment fontSize={"14px"} fontWeight={700} color={"#000"}>
-                  야호
-                </Comment>
-              </CommentWrap>
-            );
-          })}
-        </Cont>
-      </Wrap>
-      <RightSide />
-    </>
+    <Wrap>
+      <PostBox>
+        {data && (
+          <DetailPost
+            postId={data.postId}
+            author={data.author}
+            title={data.title}
+            content={data.content}
+            imgUrl={data.imgUrl}
+            like={data.like}
+            comment={data.comment}
+            key={data.postId}
+          />
+        )}
+      </PostBox>
+    </Wrap>
   );
 }
 
 export default DetailPage;
-
-function data(data: any): import("react").ReactNode {
-  throw new Error("Function not implemented.");
-}

--- a/src/recoil/store.ts
+++ b/src/recoil/store.ts
@@ -1,16 +1,16 @@
 import { atom, selector } from "recoil";
 
 // example code
-export const textState = atom<string>({
-  key: "textState", // unique ID (with respect to other atoms/selectors)
-  default: "", // default value (aka initial value)
+export const scrolledState = atom<number>({
+  key: "scrolledState", // unique ID (with respect to other atoms/selectors)
+  default: 0, // default value (aka initial value)
 });
 
-export const charCountState = selector<number>({
-  key: "charCountState", // unique ID (with respect to other atoms/selectors)
-  get: ({ get }) => {
-    const text = get(textState);
+// export const charCountState = selector<number>({
+//   key: "charCountState", // unique ID (with respect to other atoms/selectors)
+//   get: ({ get }) => {
+//     const text = get(textState);
 
-    return text.length;
-  },
-});
+//     return text.length;
+//   },
+// });

--- a/src/type/dataType.ts
+++ b/src/type/dataType.ts
@@ -1,0 +1,9 @@
+export interface PostType {
+  postId: string;
+  author: string;
+  title: string;
+  content: string;
+  imgUrl: string[];
+  like: number;
+  comment: { author: string; content: string }[];
+}


### PR DESCRIPTION
포스트의 타이틀을 클릭하면 상세 페이지 url로 이동합니다.
x를 누르면 메인 페이지로 (뒤로가기) 이동합니다.
만약 8번째 포스트를 클릭해서 8번째 상세페이지로 이동했다면 x를 눌러
메인페이지로 돌아올 떄 자동으로 스크롤을 8번째 포스트가 있는 곳으로
맞춰 사용자 경험을 좀 더 향상 했습니다.
![1](https://user-images.githubusercontent.com/86838865/169500149-15a9548f-f002-45ec-9203-2c0074390db6.png)
![2](https://user-images.githubusercontent.com/86838865/169500137-a50ac791-19cc-4098-97ae-e84194569d7a.png)


